### PR TITLE
fix: temporal smoothing enabled despite comment to remove it

### DIFF
--- a/configs/advanced_config.yaml
+++ b/configs/advanced_config.yaml
@@ -80,7 +80,7 @@ pipeline_parameters:
 a2f:
   # Remove temporal smoothing
   # used for debugging individual frames generated
-  temporal_smoothing: true
+  temporal_smoothing: false
   device_id: 0 # Which gpu id to use
   use_gpu_solver: true
 


### PR DESCRIPTION
### Problem
fix: temporal smoothing enabled despite comment to remove it

### Fix
Replace:
```
  temporal_smoothing: true
```

with:
```
  temporal_smoothing: false
```

### Files changed
- `configs/advanced_config.yaml`