### PR TITLE
fix: duplicate animation_data proto in compile list

### DIFF
--- a/proto/files_to_compile.yaml
+++ b/proto/files_to_compile.yaml
@@ -30,7 +30,6 @@ files:
     - nvidia_ace.services.a2f_controller.v1.proto
     - nvidia_ace.services.a2f.v1.proto
     - nvidia_ace.services.animation_controller.v1.proto
-    - nvidia_ace.animation_data.v1.proto
     - nvidia_ace.status.v1.proto
     - nvidia_ace.health.proto
     - nvidia_ace.services.a2f_authoring.v1.proto


### PR DESCRIPTION
### Problem
fix: duplicate animation_data proto in compile list

### Fix
Replace:
```
    - nvidia_ace.controller.v1.proto
    - nvidia_ace.emotion_aggregate.v1.proto
    - nvidia_ace.emotion_with_timecode.v1.proto
    - nvidia_ace.services.a2f_controller.v1.proto
    - nvidia_ace.services.a2f.v1.proto
    - nvidia_ace.services.animation_controller.v1.proto
    - nvidia_ace.animation_data.v1.proto
    - nvidia_ace.status.v1.proto
```

with:
```
    - nvidia_ace.controller.v1.proto
    - nvidia_ace.emotion_aggregate.v1.proto
    - nvidia_ace.emotion_with_timecode.v1.proto
    - nvidia_ace.services.a2f_controller.v1.proto
    - nvidia_ace.services.a2f.v1.proto
    - nvidia_ace.services.animation_controller.v1.proto
    - nvidia_ace.status.v1.proto
```

### Files changed
- `proto/files_to_compile.yaml`