### PR TITLE
fix: missing os.makedirs before copying generated files

### DIFF
--- a/proto/generate_code_from_protos.py
+++ b/proto/generate_code_from_protos.py
@@ -159,6 +159,7 @@ def main():
         file = ".".join(list_elm[-2:])
         fpath = os.path.join(path, file)
         if elm != fpath:
+            os.makedirs(path, exist_ok=True)
             shutil.copy2(elm, fpath)
             os.remove(elm)
     generate_init_py(".")


### PR DESCRIPTION
### Problem
fix: missing os.makedirs before copying generated files

### Fix
Replace:
```
        if elm != fpath:
            shutil.copy2(elm, fpath)
            os.remove(elm)
```

with:
```
        if elm != fpath:
            os.makedirs(path, exist_ok=True)
            shutil.copy2(elm, fpath)
            os.remove(elm)
```

### Files changed
- `proto/generate_code_from_protos.py`