### PR TITLE
fix: duplicate protobuf-gen dependency entry

### DIFF
--- a/proto/requirements.txt
+++ b/proto/requirements.txt
@@ -3,4 +3,3 @@ PyYAML==6.0.1
 grpclib==0.4.7
 googleapis-common-protos==1.60.0
 protobuf==4.24.1
-protobuf-gen==0.0.4


### PR DESCRIPTION
### Problem
fix: duplicate protobuf-gen dependency entry

### Fix
Replace:
```
protobuf-gen==0.0.4
PyYAML==6.0.1
grpclib==0.4.7
googleapis-common-protos==1.60.0
protobuf==4.24.1
protobuf-gen==0.0.4
```

with:
```
protobuf-gen==0.0.4
PyYAML==6.0.1
grpclib==0.4.7
googleapis-common-protos==1.60.0
protobuf==4.24.1
```

### Files changed
- `proto/requirements.txt`