### PR TITLE
fix: pip install command refers to requirements without .txt

### DIFF
--- a/scripts/audio2face_3d_api_client/README.md
+++ b/scripts/audio2face_3d_api_client/README.md
@@ -14,7 +14,7 @@ source .venv/bin/activate
 Then install the required dependencies:
 
 ```bash
-pip3 install -r requirements
+pip3 install -r requirements.txt
 pip3 install ../../proto/sample_wheel/nvidia_ace-1.2.0-py3-none-any.whl
 ```
 


### PR DESCRIPTION
### Problem
fix: pip install command refers to requirements without .txt

### Fix
Replace:
```
pip3 install -r requirements
```

with:
```
pip3 install -r requirements.txt
```

### Files changed
- `scripts/audio2face_3d_api_client/README.md`