### PR TITLE
fix: emotion_key_frames missing a2e_output key

### DIFF
--- a/scripts/audio2face_3d_api_client/a2f_3d/client/service.py
+++ b/scripts/audio2face_3d_api_client/a2f_3d/client/service.py
@@ -100,6 +100,7 @@ async def read_from_stream(stream):
     # Emotions 'key frames' data from input, a2e output and final a2f-3d smoothed output.
     emotion_key_frames = {
         "input": [],
+        "a2e_output": [],
         "a2f_smoothed_output": []
     }
     # Reads the content of the stream using the read() method of the StreamStreamCall object.


### PR DESCRIPTION
### Problem
fix: emotion_key_frames missing a2e_output key

### Fix
Replace:
```
    emotion_key_frames = {
        "input": [],
        "a2f_smoothed_output": []
    }
```

with:
```
    emotion_key_frames = {
        "input": [],
        "a2e_output": [],
        "a2f_smoothed_output": []
    }
```

### Files changed
- `scripts/audio2face_3d_api_client/a2f_3d/client/service.py`