### PR TITLE
fix: stray digit in lower face comment

### DIFF
--- a/scripts/audio2face_3d_api_client/config/config_james.yml
+++ b/scripts/audio2face_3d_api_client/config/config_james.yml
@@ -19,7 +19,7 @@ face_parameters:
   upperFaceStrength: 1
   # Applies temporal smoothing to the upper face motion
   upperFaceSmoothing: 0.001
-  # Controls the range of motion on the lower regions of the face1
+  # Controls the range of motion on the lower regions of the face
   lowerFaceStrength: 1.2
   # Applies temporal smoothing to the lower face motion
   lowerFaceSmoothing: 0.006


### PR DESCRIPTION
### Problem
fix: stray digit in lower face comment

### Fix
Replace:
```
  # Controls the range of motion on the lower regions of the face1
```

with:
```
  # Controls the range of motion on the lower regions of the face
```

### Files changed
- `scripts/audio2face_3d_api_client/config/config_james.yml`