### PR TITLE
fix(nim-a2f-3d-client): gRPC channel is never closed after (+1 more)

### DIFF
--- a/scripts/audio2face_3d_api_client/nim_a2f_3d_client.py
+++ b/scripts/audio2face_3d_api_client/nim_a2f_3d_client.py
@@ -22,7 +22,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
                         description="Sample python application to send audio and receive animation data and emotion data through the Audio2Face-3D API.",
                         epilog="NVIDIA CORPORATION.  All rights reserved.")
-    parser.add_argument("file", help="PCM-16 bits single channel audio file in WAV ccontainer to be sent to the Audio2Face-3D service")
+    parser.add_argument("file", help="PCM-16 bits single channel audio file in WAV container to be sent to the Audio2Face-3D service")
     parser.add_argument("config", help="Configuration file for inference models")
     parser.add_argument("--apikey", type=str, required=True, help="NGC API Key to invoke the API function")
     parser.add_argument("--function-id", type=str, required=True, default="", help="Function ID to invoke the API function")
@@ -41,8 +41,13 @@ async def main():
     write = asyncio.create_task(a2f_3d.client.service.write_to_stream(stream, args.config, args.file))
     read = asyncio.create_task(a2f_3d.client.service.read_from_stream(stream))
 
-    await write
-    await read
+    try:
+        await asyncio.gather(write, read)
+    finally:
+        write.cancel()
+        read.cancel()
+        await asyncio.gather(write, read, return_exceptions=True)
+        await channel.close()
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
This PR addresses 2 issues in `scripts/audio2face_3d_api_client/nim_a2f_3d_client.py`.

#### Fix 1
fix: gRPC channel is never closed after stream finishes

**Fix:** Replace:
```
    stream = stub.ProcessAudioStream()
    write = asyncio.create_task(a2f_3d.client.service.write_to_stream(stream, args.config, args.file))
    read = asyncio.create_task(a2f_3d.client.service.read_from_stream(stream))

    await write
    await read

if __name__ == "__main__":
```

with:
```
    stream = stub.ProcessAudioStream()
    write = asyncio.create_task(a2f_3d.client.service.write_to_stream(stream, args.config, args.file))
    read = asyncio.create_task(a2f_3d.client.service.read_from_stream(stream))

    try:
        await write
        await read
    finally:
        await channel.close()

if __name__ == "__main__":
```

#### Fix 2
fix: typo 'ccontainer' in positional audio file help text

**Fix:** Replace:
```
    parser.add_argument("file", help="PCM-16 bits single channel audio file in WAV ccontainer to be sent to the Audio2Face-3D service")
```

with:
```
    parser.add_argument("file", help="PCM-16 bits single channel audio file in WAV container to be sent to the Audio2Face-3D service")
```

### Files changed
- `scripts/audio2face_3d_api_client/nim_a2f_3d_client.py`